### PR TITLE
Add a link to details on Wikipedia's bias

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # defund-wikipedia
-Chrome Extension to delete notices on Wikipedia for donations for their biasedness and lack of desire to make amends.
+Chrome Extension to delete notices on Wikipedia for donations for their [ideological bias](https://en.wikipedia.org/w/index.php?title=Ideological_bias_on_Wikipedia&oldid=994655949#Wikipedia_co-founder_Larry_Sanger) and lack of desire to make amends.
 
 ## Process to install : 
 ### 1. Download source code from Github. Extract zip and save it at a location you can remember. 


### PR DESCRIPTION
This links to [a pre-censored version](https://en.wikipedia.org/w/index.php?title=Ideological_bias_on_Wikipedia&oldid=994655949#Wikipedia_co-founder_Larry_Sanger) of the Wikipedia page, which summarizes its co-founder's (Larry Sanger) views on the specific biases by Wikipedia. I suppose we can provide a different link; in general, it would be good to link to somewhere where the reader can glean more information regarding the bias.